### PR TITLE
fix(internal): fix version string mangling logic

### DIFF
--- a/internal/git.go
+++ b/internal/git.go
@@ -11,12 +11,11 @@ import (
 )
 
 var (
-	ForceGitVersion = flag.String("force-git-version", os.Getenv("FORCE_GIT_VERSION"), "if set, force git.tag to return this value")
-	GPGKeyFile      = flag.String("gpg-key-file", gpgKeyFileLocation(), "GPG key file to sign the package")
-	GPGKeyID        = flag.String("gpg-key-id", "", "GPG key ID to sign the package")
-	GPGKeyPassword  = flag.String("gpg-key-password", "", "GPG key password to sign the package")
-	UserName        = flag.String("git-user-name", GitUserName(), "user name in Git")
-	UserEmail       = flag.String("git-user-email", GitUserEmail(), "user email in Git")
+	GPGKeyFile     = flag.String("gpg-key-file", gpgKeyFileLocation(), "GPG key file to sign the package")
+	GPGKeyID       = flag.String("gpg-key-id", "", "GPG key ID to sign the package")
+	GPGKeyPassword = flag.String("gpg-key-password", "", "GPG key password to sign the package")
+	UserName       = flag.String("git-user-name", GitUserName(), "user name in Git")
+	UserEmail      = flag.String("git-user-email", GitUserEmail(), "user email in Git")
 )
 
 const (
@@ -52,13 +51,14 @@ func GitUserEmail() string {
 }
 
 func GitVersion() string {
-	if *ForceGitVersion != "" {
-		return *ForceGitVersion
-	}
-
 	vers, err := yeet.GitTag(context.Background())
 	if err != nil {
 		panic(err)
 	}
-	return vers[1:]
+
+	if vers[0] == 'v' {
+		return vers[1:]
+	}
+
+	return vers
 }

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -1,0 +1,40 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/TecharoHQ/yeet/internal/yeet"
+)
+
+func TestGitVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "base test",
+		},
+		{
+			name:  "with version starts with v",
+			input: "v1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "with version without v",
+			input: "1.0.0",
+			want:  "1.0.0",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			yeet.ForceGitVersion = &tt.input
+			got := GitVersion()
+
+			if tt.input != "" {
+				if got != tt.want {
+					t.Errorf("GitVersion() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/yeet/yeet.go
+++ b/internal/yeet/yeet.go
@@ -2,6 +2,7 @@ package yeet
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,6 +11,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+)
+
+var (
+	ForceGitVersion = flag.String("force-git-version", os.Getenv("FORCE_GIT_VERSION"), "if set, force git.tag to return this value")
 )
 
 // current working directory and date:time tag of app boot (useful for tagging slugs)
@@ -64,6 +69,10 @@ func Output(ctx context.Context, cmd string, args ...string) (string, error) {
 
 // GitTag returns the curreng git tag.
 func GitTag(ctx context.Context) (string, error) {
+	if *ForceGitVersion != "" {
+		return *ForceGitVersion, nil
+	}
+
 	s, err := Output(ctx, "git", "describe", "--tags", "--dirty")
 	if err != nil {
 		ee, ok := errors.Cause(err).(*exec.ExitError)


### PR DESCRIPTION
Before this assumed that all tags started with `v` and cut off the v:

```go
// current version: v1.2.3
fmt.Println(internal.GitVersion()) // 1.2.3
```

This fails horribly when versions do not start with `v`:

```go
// current version: 1.2.3
fmt.Println(internal.GitVersion()) // .2.3
```

This breaks Debian's package manager[0] horribly because `.2.3` is not a valid version number in Debian land.

There needs to be additional validation for version numbers pre-build time, but for now it's easy enough to make sure that this exact failure case doesn't happen again.

[0] https://github.com/TecharoHQ/anubis/pull/373#issuecomment-2832471884

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

# Checklist

- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
