### PR TITLE
fix(yeet): make $ fail if the commands fail

### DIFF
--- a/cmd/yeet/main.go
+++ b/cmd/yeet/main.go
@@ -76,7 +76,6 @@ func dockerpush(image string) {
 
 func buildShellCommand(literals []string, exprs ...any) string {
 	var sb strings.Builder
-	fmt.Fprintln(&sb, "set -e")
 
 	for i, value := range exprs {
 		sb.WriteString(literals[i])
@@ -102,6 +101,7 @@ func runShellCommand(ctx context.Context, literals []string, exprs ...any) (stri
 
 	runner, err := interp.New(
 		interp.StdIO(nil, &buf, os.Stderr),
+		interp.Params("-e"),
 	)
 	if err != nil {
 		return "", err

--- a/cmd/yeet/shell_test.go
+++ b/cmd/yeet/shell_test.go
@@ -1,0 +1,61 @@
+package main
+
+import "testing"
+
+func TestBuildShellCommand(t *testing.T) {
+	type args struct {
+		literals []string
+		exprs    []any
+	}
+
+	for _, tt := range []struct {
+		name   string
+		input  args
+		output string
+	}{
+		{
+			name: "basic true",
+			input: args{
+				literals: []string{"true"},
+			},
+			output: "true",
+		},
+		{
+			name: "with args",
+			input: args{
+				literals: []string{"go build -o ", ""},
+				exprs:    []any{"./var/anubis"},
+			},
+			output: `go build -o ./var/anubis`,
+		},
+		{
+			name: "with escaped args",
+			input: args{
+				literals: []string{"go build -o ", ""},
+				exprs:    []any{`$OUT`},
+			},
+			output: `go build -o '$OUT'`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildShellCommand(tt.input.literals, tt.input.exprs...)
+			if result != tt.output {
+				t.Errorf("wanted %q but got %q", tt.output, result)
+			}
+		})
+	}
+}
+
+func TestRunShellCommand(t *testing.T) {
+	_, err := runShellCommand(t.Context(), []string{"true"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunShellCommandFails(t *testing.T) {
+	_, err := runShellCommand(t.Context(), []string{"false"})
+	if err == nil {
+		t.Fatal("false should have failed but did not")
+	}
+}


### PR DESCRIPTION
Previously $ never failed if any commands run by mvdan.cc/sh/v3 failed. This caused confusing and inconsistent behaviour. Now fail the build if any of the component commands fail.

# Checklist

- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
