### PR TITLE
feat(file): add file.glob() to yeetfile JS API

### DIFF
--- a/cmd/yeet/main.go
+++ b/cmd/yeet/main.go
@@ -124,6 +124,9 @@ func fileGlob(pattern string) []string {
 	if err != nil {
 		panic(err)
 	}
+	if matches == nil {
+		return []string{}
+	}
 	return matches
 }
 

--- a/cmd/yeet/main.go
+++ b/cmd/yeet/main.go
@@ -16,6 +16,7 @@ import (
 	"al.essio.dev/pkg/shellescape"
 	yeetver "github.com/TecharoHQ/yeet"
 	"github.com/TecharoHQ/yeet/confyg/flagconfyg"
+	"github.com/TecharoHQ/yeet/internal/fileglob"
 	"github.com/TecharoHQ/yeet/internal/gitea"
 	"github.com/TecharoHQ/yeet/internal/mkapk"
 	"github.com/TecharoHQ/yeet/internal/mkdeb"
@@ -118,6 +119,14 @@ func runShellCommand(ctx context.Context, literals []string, exprs ...any) (stri
 	return buf.String(), nil
 }
 
+func fileGlob(pattern string) []string {
+	matches, err := fileglob.Glob(pattern)
+	if err != nil {
+		panic(err)
+	}
+	return matches
+}
+
 func hostname() string {
 	result, err := os.Hostname()
 	if err != nil {
@@ -205,6 +214,7 @@ func main() {
 				panic(err)
 			}
 		},
+		"glob": fileGlob,
 	})
 
 	vm.Set("git", map[string]any{

--- a/cmd/yeet/shell_test.go
+++ b/cmd/yeet/shell_test.go
@@ -1,6 +1,78 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestFileGlob(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		pattern   string
+		wantPanic bool
+		contains  string // if non-empty, at least one result must contain this substring
+		wantEmpty bool   // if true, expect zero results
+	}{
+		{
+			name:     "recursive pattern finds go files",
+			pattern:  "**/*.go",
+			contains: ".go",
+		},
+		{
+			name:     "non-recursive pattern includes main.go",
+			pattern:  "*.go",
+			contains: "main.go",
+		},
+		{
+			name:      "no match returns empty slice",
+			pattern:   "**/*.doesnotexist12345",
+			wantEmpty: true,
+		},
+		{
+			name:      "invalid pattern panics",
+			pattern:   "[invalid",
+			wantPanic: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Error("expected panic but did not get one")
+					}
+				}()
+				fileGlob(tt.pattern)
+				return
+			}
+
+			results := fileGlob(tt.pattern)
+
+			if tt.wantEmpty {
+				if len(results) != 0 {
+					t.Errorf("expected empty results, got %d: %v", len(results), results)
+				}
+				return
+			}
+
+			if len(results) == 0 {
+				t.Fatalf("expected results for pattern %q, got none", tt.pattern)
+			}
+
+			if tt.contains != "" {
+				found := false
+				for _, r := range results {
+					if strings.Contains(r, tt.contains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected at least one result containing %q, got %v", tt.contains, results)
+				}
+			}
+		})
+	}
+}
 
 func TestBuildShellCommand(t *testing.T) {
 	type args struct {

--- a/doc/api.md
+++ b/doc/api.md
@@ -124,6 +124,20 @@ docker.push("ghcr.io/xe/site/bin");
 
 ## `file`
 
+### `file.glob`
+
+Returns an array of file paths matching a glob pattern relative to the current working directory. Supports standard glob wildcards (`*`, `?`, `[...]`) and `**` for recursive directory matching.
+
+Usage:
+
+`file.glob(pattern);`
+
+```js
+const goFiles = file.glob("**/*.go");
+const configs = file.glob("*.json");
+const srcOnly = file.glob("src/**/*.ts");
+```
+
 ### `file.install`
 
 Copies from a file from one place to another whilst preserving the file mode, analogous to `install -d` on Linux. Automatically creates directories in the `dest` path if they don't exist already.

--- a/internal/fileglob/fileglob.go
+++ b/internal/fileglob/fileglob.go
@@ -1,0 +1,100 @@
+package fileglob
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// Glob returns all files matching pattern relative to the current directory.
+// In addition to standard filepath.Match wildcards (*, ?, [...]) it supports
+// ** to match zero or more directories.
+func Glob(pattern string) ([]string, error) {
+	if !strings.Contains(pattern, "**") {
+		return filepath.Glob(pattern)
+	}
+
+	var matches []string
+	root := staticPrefix(pattern)
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		matched, matchErr := Match(pattern, filepath.ToSlash(path))
+		if matchErr != nil {
+			return matchErr
+		}
+		if matched {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+
+	return matches, err
+}
+
+// Match reports whether name matches the glob pattern.
+// The pattern may use ** to match zero or more path segments.
+func Match(pattern, name string) (bool, error) {
+	return matchParts(
+		strings.Split(pattern, "/"),
+		strings.Split(name, "/"),
+	)
+}
+
+func matchParts(pat, name []string) (bool, error) {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			pat = pat[1:]
+
+			if len(pat) == 0 {
+				return true, nil
+			}
+
+			// Try the remaining pattern against every suffix of name.
+			for i := 0; i <= len(name); i++ {
+				if ok, err := matchParts(pat, name[i:]); err != nil {
+					return false, err
+				} else if ok {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+
+		if len(name) == 0 {
+			return false, nil
+		}
+
+		matched, err := filepath.Match(pat[0], name[0])
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+
+		pat = pat[1:]
+		name = name[1:]
+	}
+
+	return len(name) == 0, nil
+}
+
+// staticPrefix returns the longest path prefix that contains no wildcards.
+func staticPrefix(pattern string) string {
+	parts := strings.Split(pattern, "/")
+	var prefix []string
+	for _, p := range parts {
+		if p == "**" || strings.ContainsAny(p, "*?[") {
+			break
+		}
+		prefix = append(prefix, p)
+	}
+	if len(prefix) == 0 {
+		return "."
+	}
+	return strings.Join(prefix, "/")
+}

--- a/internal/fileglob/fileglob.go
+++ b/internal/fileglob/fileglob.go
@@ -10,7 +10,7 @@ import (
 // In addition to standard filepath.Match wildcards (*, ?, [...]) it supports
 // ** to match zero or more directories.
 func Glob(pattern string) ([]string, error) {
-	if !strings.Contains(pattern, "**") {
+	if !hasDoubleStarSegment(pattern) {
 		return filepath.Glob(pattern)
 	}
 
@@ -20,6 +20,10 @@ func Glob(pattern string) ([]string, error) {
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if d.IsDir() {
+			return nil
 		}
 
 		matched, matchErr := Match(pattern, filepath.ToSlash(path))
@@ -35,12 +39,26 @@ func Glob(pattern string) ([]string, error) {
 	return matches, err
 }
 
+// hasDoubleStarSegment reports whether pattern contains a "**" as a
+// complete path segment (i.e. between slashes or at start/end), which is
+// the only position where Match treats it specially.
+func hasDoubleStarSegment(pattern string) bool {
+	for seg := range strings.SplitSeq(filepath.ToSlash(pattern), "/") {
+		if seg == "**" {
+			return true
+		}
+	}
+	return false
+}
+
 // Match reports whether name matches the glob pattern.
 // The pattern may use ** to match zero or more path segments.
+// Both pattern and name are normalized to forward slashes before matching
+// so that callers on Windows can pass either separator.
 func Match(pattern, name string) (bool, error) {
 	return matchParts(
-		strings.Split(pattern, "/"),
-		strings.Split(name, "/"),
+		strings.Split(filepath.ToSlash(pattern), "/"),
+		strings.Split(filepath.ToSlash(name), "/"),
 	)
 }
 

--- a/internal/fileglob/fileglob_test.go
+++ b/internal/fileglob/fileglob_test.go
@@ -1,0 +1,122 @@
+package fileglob
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	for _, tt := range []struct {
+		pattern string
+		name    string
+		want    bool
+	}{
+		{"**/*.go", "main.go", true},
+		{"**/*.go", "cmd/yeet/main.go", true},
+		{"**/*.go", "README.md", false},
+		{"cmd/**/*.go", "cmd/yeet/main.go", true},
+		{"cmd/**/*.go", "internal/foo.go", false},
+		{"*.go", "main.go", true},
+		{"*.go", "cmd/main.go", false},
+		{"**/*", "a/b/c", true},
+		{"**/b/*", "a/b/c", true},
+		{"a/**/c", "a/c", true},
+		{"a/**/c", "a/b/c", true},
+		{"a/**/c", "a/b/d/c", true},
+		{"[invalid", "x", false}, // filepath.Match returns error
+	} {
+		t.Run(tt.pattern+"_"+tt.name, func(t *testing.T) {
+			got, err := Match(tt.pattern, tt.name)
+			if tt.pattern == "[invalid" {
+				if err == nil {
+					t.Fatal("expected error for invalid pattern")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("Match(%q, %q) = %v, want %v", tt.pattern, tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGlob(t *testing.T) {
+	// Build a temp tree to glob against.
+	tmp := t.TempDir()
+
+	files := []string{
+		"a.go",
+		"b.txt",
+		"src/main.go",
+		"src/util/helpers.go",
+		"src/util/helpers_test.go",
+		"docs/readme.md",
+	}
+	for _, f := range files {
+		p := filepath.Join(tmp, f)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// chdir so relative patterns work against our temp tree
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(tmp)
+
+	for _, tt := range []struct {
+		name    string
+		pattern string
+		want    int // expected match count
+	}{
+		{"recursive go files", "**/*.go", 4},
+		{"scoped recursive", "src/**/*.go", 3},
+		{"single level", "*.go", 1},
+		{"no matches", "**/*.rs", 0},
+		{"non-recursive subdir", "src/*.go", 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := Glob(tt.pattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) != tt.want {
+				t.Errorf("Glob(%q): got %d matches %v, want %d", tt.pattern, len(matches), matches, tt.want)
+			}
+		})
+	}
+}
+
+func TestGlobInvalidPattern(t *testing.T) {
+	_, err := Glob("[invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid pattern")
+	}
+}
+
+func TestStaticPrefix(t *testing.T) {
+	for _, tt := range []struct {
+		pattern string
+		want    string
+	}{
+		{"**/*.go", "."},
+		{"src/**/*.go", "src"},
+		{"a/b/c/*.go", "a/b/c"},
+		{"*.go", "."},
+		{"a/b/**/c", "a/b"},
+	} {
+		t.Run(tt.pattern, func(t *testing.T) {
+			got := staticPrefix(tt.pattern)
+			if got != tt.want {
+				t.Errorf("staticPrefix(%q) = %q, want %q", tt.pattern, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fileglob/fileglob_test.go
+++ b/internal/fileglob/fileglob_test.go
@@ -67,9 +67,18 @@ func TestGlob(t *testing.T) {
 	}
 
 	// chdir so relative patterns work against our temp tree
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(orig) })
-	os.Chdir(tmp)
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Errorf("restoring working directory: %v", err)
+		}
+	})
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir(%s): %v", tmp, err)
+	}
 
 	for _, tt := range []struct {
 		name    string


### PR DESCRIPTION
Add glob pattern matching with ** recursive directory support to the file namespace. Implemented in internal/fileglob using only the standard library (filepath.WalkDir + filepath.Match).

Assisted-by: Claude Opus 4.6 via Claude Code

<!--
delete me and describe your change here, give enough context for a maintainer to understand what and why

See https://anubis.techaro.lol/docs/developer/code-quality for more information
-->

# Checklist

- [x] Added test cases to [the relevant parts of the codebase](https://anubis.techaro.lol/docs/developer/code-quality)
